### PR TITLE
[WIP] Convert to non-virtualenv deployment

### DIFF
--- a/bifrost.yml
+++ b/bifrost.yml
@@ -11,7 +11,7 @@
         BIFROST_INVENTORY_SOURCE: "{{ bifrost_inventory_path }}"
 
   environment:
-    VENV: /opt/stack/bifrost
+    VENV: "{{ bifrost_venv_path }}"
 
   tasks: []
   roles:

--- a/roles/bifrost-install/tasks/main.yml
+++ b/roles/bifrost-install/tasks/main.yml
@@ -3,11 +3,6 @@
 # http://docs.openstack.org/developer/bifrost/readme.html
 # ...up to the end of the "installation" section.
 
-- name: Enable EPEL
-  package:
-    name: epel-release
-    state: present
-
 - name: Install dependencies
   package:
     name: "{{ item }}"
@@ -17,9 +12,16 @@
     - mlocate
     - ntp
 
+- name: Check if NTP daemon is running
+  command: systemctl status ntpd
+  ignore_errors: true
+  changed_when: false
+  register: service_ntpd_status
+
 - name: Update time with ntp
   command: ntpdate pool.ntp.org
   ignore_errors: true
+  when: service_ntpd_status | failed
 
 - name: Start and enable NTP daemon
   systemd:
@@ -27,71 +29,44 @@
     state: started
     enabled: true
 
-- name: Disable selinux
+- name: Disable SElinux
   selinux:
     state: disabled
 
-- name: Generate an SSH key for root
-  user:
-    name: root
-    generate_ssh_key: yes
-    ssh_key_bits: 2048
-    ssh_key_file: .ssh/id_rsa
-
 - name: Wipe bifrost clone
   file:
-    path: /usr/src/bifrost
+    path: "{{ bifrost_repo_path }}"
     state: absent
 
 - name: Clone bifrost
   git:
     repo: "{{ bifrost_repo }}"
-    dest: /usr/src/bifrost
+    dest: "{{ bifrost_repo_path }}"
     version: "{{ bifrost_version }}"
 
 - name: Template group vars
   template:
     src: "group_vars.{{ item }}.j2"
-    dest: "/usr/src/bifrost/playbooks/inventory/group_vars/{{ item }}"
+    dest: "{{ bifrost_repo_path }}/playbooks/inventory/group_vars/{{ item }}"
   with_items:
     - baremetal
     - localhost
     - target
 
-- name: Make sure our Python dependencies are active
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - python
-    - python-devel
-    - python-pip
-    - python-virtualenv
-
 - name: Run the env setup script
   shell: >
-    bash /usr/src/bifrost/scripts/env-setup.sh
-
-- name: Make sure we have the venv setup
-  stat:
-    path: /opt/stack/bifrost/bin/activate
-  register: bifrost_venv
-
-- name: Fail if we don't have a venv
-  fail:
-    msg: VENV didn't get setup properly
-  when: not bifrost_venv.stat.exists
+    bash {{ bifrost_repo_path }}/scripts/env-setup.sh
 
 - name: Annnnd! We run the installation playbook.
   shell: >
-    source /opt/stack/bifrost/bin/activate && \
-    source /usr/src/bifrost/env-vars && \
-    /opt/stack/bifrost/bin/ansible-playbook -i inventory/target install.yaml
+    {{ bifrost_venv_path }}/bin/ansible-playbook -i inventory/target install.yaml
   args:
-    chdir: /usr/src/bifrost/playbooks
-    creates: /etc/.bifrost-installed
+    chdir: "{{ bifrost_repo_path }}/playbooks"
+    creates: "{{ bifrost_repo_path }}/.bifrost-installed"
+  tags:
+    - remote_deploy
 
 - name: Mark bifrost install complete
   file:
-    path: /etc/.bifrost-installed
+    path: "{{ bifrost_repo_path }}/.bifrost-installed"
     state: directory

--- a/roles/bifrost-inventory/tasks/main.yml
+++ b/roles/bifrost-inventory/tasks/main.yml
@@ -7,45 +7,19 @@
 # Unsure if I'll really need this, but, for now.
 - name: Get enrolled inventory
   shell: >
-    source /opt/stack/bifrost/bin/activate && \
     ironic node-list
   environment: "{{ bifrost_env }}"
   register: enrolled_inventory
 
 - name: Start enrollment, enroll everything every time.
   shell: >
-    source /opt/stack/bifrost/bin/activate && \
-    source /usr/src/bifrost/env-vars && \
-    /opt/stack/bifrost/bin/ansible-playbook -i inventory/bifrost_inventory.py enroll-dynamic.yaml
+    {{ bifrost_venv_path }}/bin/ansible-playbook -i inventory/bifrost_inventory.py enroll-dynamic.yaml
   args:
-    chdir: /usr/src/bifrost/playbooks
+    chdir: "{{ bifrost_repo_path }}/playbooks"
   environment: "{{ bifrost_env }}"
 
 - name: Set root device for each inventory item, every time.
   shell: >
-    source /opt/stack/bifrost/bin/activate && \
     ironic node-update {{ item.uuid }} add properties/root_device='{"{{ item.root_device_type }}": "{{ item.root_device }}"}'
   with_items: "{{ bifrost_inventory }}"
   environment: "{{ bifrost_env }}"
-
-# - name: Now give the deployment command
-#   debug:
-#     msg: "cd /usr/src/bifrost/playbooks && export BIFROST_INVENTORY_SOURCE= && ansible-playbook -vvvv -i inventory/bifrost_inventory.py deploy-dynamic.yaml"
-
-#- name: Kick off the deployment
-#  shell: >
-#    ansible-playbook -vvvv -i inventory/bifrost_inventory.py deploy-dynamic.yaml
-#  args:
-#    chdir: /usr/src/bifrost/playbooks
-#  environment: "{{ bifrost_env }}"
-
-
-# - debug: "msg={{ enrolled_inventory.stdout }}"
-
-# - name: Check the BIFROST_INVENTORY_SOURCE
-#   shell: >
-#     echo $BIFROST_INVENTORY_SOURCE
-#   environment: "{{ bifrost_env }}"
-#   register: checksource
-
-# - debug: "msg={{ checksource.stdout }}"

--- a/vars/bifrost.yml
+++ b/vars/bifrost.yml
@@ -1,3 +1,4 @@
 bifrost: true
-bifrost_inventory_path: /root/inventory.json
-
+bifrost_repo_path: /opt/bifrost
+bifrost_venv_path: /opt/stack/bifrost
+bifrost_inventory_path: /opt/inventory


### PR DESCRIPTION
We were making bootstrap way too complicated.
This change is intended to make the install a bit more
native, which makes the remote Ansible reployment much
easier to implement and execute.