### PR TITLE
Complete venv removal

### DIFF
--- a/bifrost.yml
+++ b/bifrost.yml
@@ -10,9 +10,6 @@
         OS_AUTH_TOKEN: "fake-token"
         BIFROST_INVENTORY_SOURCE: "{{ bifrost_inventory_path }}"
 
-  environment:
-    VENV: "{{ bifrost_venv_path }}"
-
   tasks: []
   roles:
     - { role: bifrost-install }

--- a/roles/bifrost-install/tasks/main.yml
+++ b/roles/bifrost-install/tasks/main.yml
@@ -11,6 +11,19 @@
     - git
     - mlocate
     - ntp
+    - epel-release
+
+# grrrr at lack of cache update
+- name: Install Python and Ansible
+  yum:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - python
+    - python-devel
+    - python-pip
+    - ansible
 
 - name: Check if NTP daemon is running
   command: systemctl status ntpd
@@ -53,13 +66,15 @@
     - localhost
     - target
 
-- name: Run the env setup script
-  shell: >
-    bash {{ bifrost_repo_path }}/scripts/env-setup.sh
+# TODO: this should be removed after this is merged: https://review.openstack.org/#/c/471750
+- name: Upgrade setuptools with pip
+  pip:
+    name: setuptools
+    extra_args: --upgrade
 
 - name: Annnnd! We run the installation playbook.
   shell: >
-    {{ bifrost_venv_path }}/bin/ansible-playbook -i inventory/target install.yaml
+    ansible-playbook -i inventory/target install.yaml
   args:
     chdir: "{{ bifrost_repo_path }}/playbooks"
     creates: "{{ bifrost_repo_path }}/.bifrost-installed"

--- a/roles/bifrost-inventory/tasks/main.yml
+++ b/roles/bifrost-inventory/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Start enrollment, enroll everything every time.
   shell: >
-    {{ bifrost_venv_path }}/bin/ansible-playbook -i inventory/bifrost_inventory.py enroll-dynamic.yaml
+    ansible-playbook -i inventory/bifrost_inventory.py enroll-dynamic.yaml
   args:
     chdir: "{{ bifrost_repo_path }}/playbooks"
   environment: "{{ bifrost_env }}"
@@ -23,3 +23,4 @@
     ironic node-update {{ item.uuid }} add properties/root_device='{"{{ item.root_device_type }}": "{{ item.root_device }}"}'
   with_items: "{{ bifrost_inventory }}"
   environment: "{{ bifrost_env }}"
+  when: item.root_device_type is defined and item.root_device is defined

--- a/vars/bifrost.yml
+++ b/vars/bifrost.yml
@@ -1,4 +1,3 @@
 bifrost: true
 bifrost_repo_path: /opt/bifrost
-bifrost_venv_path: /opt/stack/bifrost
 bifrost_inventory_path: /opt/inventory


### PR DESCRIPTION
Removal of the venv has made bootstrapping and
installing bifrost significantly easier. Instead
of using a venv and polluting the system with pip
based installation, we're using Ansible installed
via epel-release.

Deployment of bifrost is much more consistent, and
the import of the hardware into ironic is working
exactly as it should.