### PR TITLE
Download instead of building IPA image

### DIFF
--- a/roles/bifrost-install/templates/group_vars.localhost.j2
+++ b/roles/bifrost-install/templates/group_vars.localhost.j2
@@ -59,7 +59,7 @@ dib_os_element: "centos7"
 transform_boot_image: false
 
 # Create IPA image instead of downloading an pre-made CoreOS IPA image.
-create_ipa_image: true
+create_ipa_image: false
 
 # Dnsmasq default route for clients. If not defined, dnsmasq will push to
 # clients as default route the same IP of the dnsmasq server.

--- a/roles/bifrost-install/templates/group_vars.target.j2
+++ b/roles/bifrost-install/templates/group_vars.target.j2
@@ -59,7 +59,7 @@ dib_os_element: "centos7"
 transform_boot_image: false
 
 # Create IPA image instead of downloading an pre-made CoreOS IPA image.
-create_ipa_image: true
+create_ipa_image: false
 
 # Dnsmasq default route for clients. If not defined, dnsmasq will push to
 # clients as default route the same IP of the dnsmasq server.


### PR DESCRIPTION
Building the IPA image isn't really necessary since we
can just download the pre-built CoreOS based image.

Closes #17