### PR TITLE
Don't make bifrost the default route

### DIFF
--- a/roles/bifrost-install/templates/group_vars.localhost.j2
+++ b/roles/bifrost-install/templates/group_vars.localhost.j2
@@ -69,6 +69,7 @@ create_ipa_image: false
 # Dnsmasq default nameserver for clients. If not defined, this setting
 # will be ignored.
 # Default: undefined
+default_router: false
 dnsmasq_dns_servers: 8.8.8.8,8.8.4.4
 dhcp_pool_start: {{ pxe_dhcp_start }}
 dhcp_pool_end: {{ pxe_dhcp_end }}

--- a/roles/bifrost-install/templates/group_vars.target.j2
+++ b/roles/bifrost-install/templates/group_vars.target.j2
@@ -69,6 +69,7 @@ create_ipa_image: false
 # Dnsmasq default nameserver for clients. If not defined, this setting
 # will be ignored.
 # Default: undefined
+dnsmasq_router: false
 dnsmasq_dns_servers: 8.8.8.8,8.8.4.4
 dhcp_pool_start: {{ pxe_dhcp_start }}
 dhcp_pool_end: {{ pxe_dhcp_end }}


### PR DESCRIPTION
Pass a variable to bifrost so that the default route isn't
set in dnsmasq as the bifrost server. In this case, it'll
be assumed that you have another interface that will advertise
itself as the default route.